### PR TITLE
Multiple modifications

### DIFF
--- a/hotel/report/hotel_folio_report_template.xml
+++ b/hotel/report/hotel_folio_report_template.xml
@@ -17,9 +17,9 @@
                     <div class="row mt32 mb32">
                         <div class="text-center">
                             <strong>From:</strong>
-                            <span t-esc="data['date_start']" />
+                            <span t-esc="date_start" />
                             <strong>To:</strong>
-                            <span t-esc="data['date_end']" />
+                            <span t-esc="date_end" />
                         </div>
                     </div>
                     <table class="table table-condensed">

--- a/hotel/report/hotel_report.py
+++ b/hotel/report/hotel_report.py
@@ -1,18 +1,18 @@
 # See LICENSE file for full copyright and licensing details.
 
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
 from dateutil.relativedelta import relativedelta
 from dateutil import parser
 from odoo import api, fields, models
-
+import pytz
 
 class FolioReport(models.AbstractModel):
     _name = 'report.hotel.report_hotel_folio'
     _description = 'Auxiliar to get the report'
 
-    def _get_folio_data(self, date_start, date_end):
+    def _get_folio_data(self, date_start, date_end, user_lang, to_zone):
         total_amount = 0.0
         data_folio = []
         folio_obj = self.env['hotel.folio']
@@ -20,20 +20,30 @@ class FolioReport(models.AbstractModel):
                       ('checkout_date', '<=', date_end)]
         tids = folio_obj.search(act_domain)
         for data in tids:
-            checkin = data.checkin_date.\
-                strftime(DEFAULT_SERVER_DATETIME_FORMAT)
-            checkout = data.checkout_date.\
-                strftime(DEFAULT_SERVER_DATETIME_FORMAT)
+            checkin = self.format_date(data.checkin_date, user_lang, to_zone)
+            checkout = self.format_date(data.checkout_date, user_lang, to_zone)
             data_folio.append({
                 'name': data.name,
                 'partner': data.partner_id.name,
-                'checkin': parser.parse(checkin),
-                'checkout': parser.parse(checkout),
+                'checkin': checkin,
+                'checkout': checkout,
                 'amount': data.amount_total
             })
             total_amount += data.amount_total
         data_folio.append({'total_amount': total_amount})
         return data_folio
+
+    def format_date(self, date, user_lang, to_zone):
+        if isinstance(date, str):
+            new_date = datetime.strptime(date, '%Y-%m-%d %H:%M:%S')
+        else:
+            new_date = date
+        timezone_conv = pytz.timezone(to_zone)
+        timezone_utc = pytz.timezone('UTC')
+        new_date = timezone_utc.localize(new_date)
+        new_date = new_date.astimezone(timezone_conv)
+        date_converted = new_date.strftime(user_lang.date_format+" "+user_lang.time_format)
+        return date_converted
 
     @api.model
     def _get_report_values(self, docids, data):
@@ -42,16 +52,29 @@ class FolioReport(models.AbstractModel):
             data = {}
         if not docids:
             docids = data['form'].get('docids')
-        folio_profile = self.env['hotel.folio'].browse(docids)
-        date_start = data['form'].get('date_start', fields.Date.today())
-        date_end = data['form'].get(
-            'date_end', str(datetime.now() + relativedelta(
-                months=+1, day=1, days=-1))[:10])
+        context = self._context
+        current_uid = context.get('uid')
+        user = self.env['res.users'].browse(current_uid)
+        user_lang = self.env['res.lang'].search([('code', '=', user.lang)])[0]
+        if self._context.get('tz'):
+            to_zone = self._context.get('tz')
+        else:
+            to_zone = 'UTC'
+        rm_act = self.with_context(data['form'].get('used_context', {}))
+        folio_profile = self.env['hotel.reservation'].browse(docids)
+        date_start = data['form'].get('date_start', str(datetime.now())[:10])
+        date_end = data['form'].get('date_end', str(datetime.now() +
+                                    relativedelta(months=+1,
+                                                  day=1, days=-1))[:10])
+        date_start_formatted = rm_act.format_date(date_start, user_lang, to_zone)
+        date_end_formatted = rm_act.format_date(date_end, user_lang, to_zone)
         return {
             'doc_ids': docids,
             'doc_model': self.model,
             'data': data['form'],
             'docs': folio_profile,
             'time': time,
-            'folio_data': self._get_folio_data(date_start, date_end)
+            'folio_data': self._get_folio_data(date_start, date_end, user_lang, to_zone),
+            'date_start': date_start_formatted,
+            'date_end': date_end_formatted
         }

--- a/hotel/security/ir.model.access.csv
+++ b/hotel/security/ir.model.access.csv
@@ -15,6 +15,7 @@ access_hotel_order_user,hotel.order.user,sale.model_sale_order,hotel.group_hotel
 access_hotel_order_line_user,hotel.order.line.user,sale.model_sale_order_line,hotel.group_hotel_user,1,1,1,0
 access_hotel_invoice_user,account.invoice.user,account.model_account_invoice,hotel.group_hotel_user,1,1,1,0
 access_folio_room_line_user,hotel.folio_room_line.user,model_folio_room_line,hotel.group_hotel_user,1,1,1,1
+access_folio_report_wizard_user,hotel.folio.report.wizard.user,model_folio_report_wizard,hotel.group_hotel_user,1,1,1,0
 access_hotel_floor_group_manager,hotel.floor.manager,model_hotel_floor,hotel.group_hotel_manager,1,1,1,1
 access_product_category_manager,product.category.manager,product.model_product_category,hotel.group_hotel_manager,1,1,1,1
 access_hotel_room_type_manager,hotel.room_type.manager,model_hotel_room_type,hotel.group_hotel_manager,1,1,1,1
@@ -31,3 +32,4 @@ access_hotel_order_manager_manager,hotel.order.manager,sale.model_sale_order,hot
 access_hotel_order_line_manager,hotel.order.line.manager,sale.model_sale_order_line,hotel.group_hotel_manager,1,1,1,0
 access_hotel_invoice_manager,account.invoice.manager,account.model_account_invoice,hotel.group_hotel_manager,1,1,1,1
 access_folio_room_line_manager,hotel.folio_room_line.manager,model_folio_room_line,hotel.group_hotel_manager,1,1,1,1
+access_folio_report_wizard_manager,hotel.folio.report.wizard.manager,model_folio_report_wizard,hotel.group_hotel_manager,1,1,1,1

--- a/hotel/views/hotel_view.xml
+++ b/hotel/views/hotel_view.xml
@@ -541,9 +541,11 @@
                                 <form string="Room Line">
                                     <notebook>
                                         <page name="folio_name" string="Folio Line">
+                                            <separator string="Reservation" colspan="4" />
+                                            <field name="reservation" colspan="4" select="2" readonly="1"/>
                                             <group col="6" colspan="4">
-                                                <field name="checkin_date" />
-                                                <field name="checkout_date" />
+                                                <field name="checkin_date" readonly="1"/>
+                                                <field name="checkout_date" readonly="1"/>
                                                 <separator string="Automatic Declaration" col="6"
                                                     colspan="4" />
                                                 <field name="product_uom_qty"
@@ -551,14 +553,14 @@
                                                     invisible="1" />
                                                 <field name="product_id"
                                                     context="{'partner_id':parent.partner_id,'quantity':product_uom_qty,'pricelist':parent.pricelist_id,'uom':product_uom}"
-                                                    domain="[('isroom','=',True)]" string="Room No" />
-                                                <field name="product_uom" string="Rent(UOM)" />
+                                                    domain="[('isroom','=',True)]" string="Room No" readonly="1"/>
+                                                <field name="product_uom" string="Rent(UOM)" readonly="1"/>
                                             </group>
                                             <separator string="Manual Description" colspan="4" />
                                             <field name="name" colspan="4" select="2"
                                                 placeholder="Description" />
                                             <group col="4" colspan="2">
-                                                <field name="price_unit" select="2" string="Rent" />
+                                                <field name="price_unit" select="2" string="Rent" readonly="1"/>
                                                 <field name="discount" />
                                                 <newline />
                                                 <field name="tax_id" colspan="4" nolabel="1" />
@@ -575,7 +577,7 @@
                                     </notebook>
                                 </form>
                                 <tree string="Room Line">
-                                    <field name="name" />
+                                    <field name="reservation" />
                                     <field name="checkin_date" />
                                     <field name="checkout_date" />
                                     <field name="product_id" string="Room No" />
@@ -659,6 +661,10 @@
                         </page>
                     </notebook>
                 </sheet>
+                <div class="oe_chatter">
+					<field name="message_follower_ids" widget="mail_followers"/>
+					<field name="message_ids" widget="mail_thread"/>
+				</div>
             </form>
         </field>
     </record>

--- a/hotel/wizard/hotel_wizard.py
+++ b/hotel/wizard/hotel_wizard.py
@@ -1,6 +1,82 @@
 # See LICENSE file for full copyright and licensing details.
 
+import time
+from datetime import datetime, timedelta
+from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
 from odoo import api, fields, models
+
+def _offset_format_timestamp1(src_tstamp_str, src_format, dst_format,
+                              ignore_unparsable_time=True, context=None):
+    """
+    Convert a source timeStamp string into a destination timeStamp string,
+    attempting to apply the correct offset if both the server and local
+    timeZone are recognized,or no offset at all if they aren't or if
+    tz_offset is false (i.e. assuming they are both in the same TZ).
+
+    @param src_tstamp_str: the STR value containing the timeStamp.
+    @param src_format: the format to use when parsing the local timeStamp.
+    @param dst_format: the format to use when formatting the resulting
+     timeStamp.
+    @param server_to_client: specify timeZone offset direction (server=src
+                             and client=dest if True, or client=src and
+                             server=dest if False)
+    @param ignore_unparsable_time: if True, return False if src_tstamp_str
+                                   cannot be parsed using src_format or
+                                   formatted using dst_format.
+    @return: destination formatted timestamp, expressed in the destination
+             timezone if possible and if tz_offset is true, or src_tstamp_str
+             if timezone offset could not be determined.
+    """
+    if not src_tstamp_str:
+        return False
+    res = src_tstamp_str
+    if src_format and dst_format:
+        try:
+            # dt_value needs to be a datetime object\
+            # (so notime.struct_time or mx.DateTime.DateTime here!)
+            dt_value = datetime.strptime(src_tstamp_str, src_format)
+            if context.get('tz', False):
+                try:
+                    import pytz
+                    src_tz = pytz.timezone(context['tz'])
+                    dst_tz = pytz.timezone('UTC')
+                    src_dt = src_tz.localize(dt_value, is_dst=True)
+                    dt_value = src_dt.astimezone(dst_tz)
+                except Exception:
+                    pass
+            res = dt_value.strftime(dst_format)
+        except Exception:
+            # Normal ways to end up here are if strptime or strftime failed
+            if not ignore_unparsable_time:
+                return False
+            pass
+    return res
+
+def _get_checkin_date(self):
+    if self._context.get('tz'):
+        to_zone = self._context.get('tz')
+    else:
+        to_zone = 'UTC'
+    return datetime.strptime(_offset_format_timestamp1(time.strftime("%Y-%m-%d 15:00:00"),
+                                     DEFAULT_SERVER_DATETIME_FORMAT,
+                                     DEFAULT_SERVER_DATETIME_FORMAT,
+                                     ignore_unparsable_time=True,
+                                     context={'tz': to_zone}),
+                                     '%Y-%m-%d %H:%M:%S')
+
+def _get_checkout_date(self):
+    if self._context.get('tz'):
+        to_zone = self._context.get('tz')
+    else:
+        to_zone = 'UTC'
+    tm_delta = timedelta(days=1)
+    return datetime.strptime(_offset_format_timestamp1
+                             (time.strftime("%Y-%m-%d 11:00:00"),
+                              DEFAULT_SERVER_DATETIME_FORMAT,
+                              DEFAULT_SERVER_DATETIME_FORMAT,
+                              ignore_unparsable_time=True,
+                              context={'tz': to_zone}),
+                             '%Y-%m-%d %H:%M:%S') + tm_delta
 
 
 class FolioReportWizard(models.TransientModel):
@@ -8,8 +84,10 @@ class FolioReportWizard(models.TransientModel):
     _rec_name = 'date_start'
     _description = 'Allow print folio report by date'
 
-    date_start = fields.Datetime('Start Date')
-    date_end = fields.Datetime('End Date')
+    date_start = fields.Datetime('Start Date',
+                              default=_get_checkin_date)
+    date_end = fields.Datetime('End Date',
+                              default=_get_checkout_date)
 
     @api.multi
     def print_report(self):

--- a/hotel_reservation/data/email_template_view.xml
+++ b/hotel_reservation/data/email_template_view.xml
@@ -16,24 +16,24 @@
                 <p style="margin: 0px; padding: 0px; font-size: 13px;">
                 <p>Hello <strong>${object.partner_id.name}</strong>,</p>
                 <p>This is to confirm your booking for a room at the <strong>${object.warehouse_id.name} Hotel</strong>,
-                   % if object.warehouse_id.partner_id.city: 
+                   % if object.warehouse_id.partner_id.city:
                    <strong>${object.warehouse_id.partner_id.city}</strong>,
-                   % endif 
+                   % endif
                    % if object.warehouse_id.partner_id.country_id.name:
                    <strong>${object.warehouse_id.partner_id.country_id.name}</strong>.
                    % endif
                    On behalf of the hotel, we would like to express our gratitude to you for choosing our services. 
-                   Please find all the details regarding the confirmation of the reservation on Date <strong>${object.date_order}</strong> are listed below:
+                   Please find all the details regarding the confirmation of the reservation on Date <strong>${object.format_date(object.date_order, object.partner_id.lang)[0]}</strong> are listed below:
                 </p>
-                        <strong>Details :</strong><br/>
+                <strong>Details :</strong><br/>
                 <p style="border-left: 1px solid #8e0000; margin-left: 30px;">
-                        Name Of Guest : <strong>${object.partner_id.name}</strong><br />
-                        Date Of Arrival : <strong>${object.checkin}</strong><br />
-                        Date Of Departure : <strong>${object.checkout}</strong><br />
-                        Reservation Number : <strong>${object.reservation_no}</strong><br />
-                        Number Of Persons : <strong>${object.adults}</strong> Adults and <strong>${object.children}</strong> Childrens<br />
+                Name Of Guest : <strong>${object.partner_id.name}</strong><br />
+                Date Of Arrival : <strong>${object.format_date(object.checkin, object.partner_id.lang)[0]}</strong><br />
+                Date Of Departure : <strong>${object.format_date(object.checkout, object.partner_id.lang)[0]}</strong><br />
+                Reservation Number : <strong>${object.reservation_no}</strong><br />
+                Number Of Persons : <strong>${object.adults}</strong> Adults and <strong>${object.children}</strong> Childrens<br />
                 </p>
-                    <strong>Rooms Rates Per Night :</strong><br/>
+                <strong>Rooms Rates Per Night :</strong><br/>
                 <br/>
                 <table border="1" cellpadding="4" style="margin-left: 30px;">
                         <tr>
@@ -74,11 +74,11 @@
                % if object.warehouse_id.partner_id.website:
                <strong>${object.warehouse_id.partner_id.website}</strong> <br />
                % endif
-                </p>
-                </div>
+               </p>
+               </div>
             </field>
         </record>
-    
+
         <!-- Email Template For Hotel Reservation Reminder Before 24 Hours -->
         <record id="mail_template_reservation_reminder_24hrs" model="mail.template">
             <field name="name">Reservation Reminder Before 24hrs</field>
@@ -101,15 +101,15 @@
                    % if object.warehouse_id.partner_id.country_id.name:
                    <strong>${object.warehouse_id.partner_id.country_id.name}</strong>.
                    % endif
-                    Your checkin has been confirmed on Date <strong>${object.date_order}</strong>.
+                    Your checkin has been confirmed on Date <strong>${object.format_date(object.date_order, object.partner_id.lang)[0]}</strong>.
                    Please find all the details regarding to the reservation as listed below:
                 </p>
                 <br/>
                 <strong>Details :</strong><br/>
                 <p style="border-left: 1px solid #8e0000; margin-left: 30px;">
                 &amp;nbsp;&amp;nbsp;Name Of Guest : <strong>${object.partner_id.name}</strong><br />
-                &amp;nbsp;&amp;nbsp;Date Of Arrival : <strong>${object.checkin}</strong><br />
-                &amp;nbsp;&amp;nbsp;Date Of Departure : <strong>${object.checkout}</strong><br />
+                &amp;nbsp;&amp;nbsp;Date Of Arrival : <strong>${object.format_date(object.checkin, object.partner_id.lang)[0]}</strong><br />
+                &amp;nbsp;&amp;nbsp;Date Of Departure : <strong>${object.format_date(object.checkout, object.partner_id.lang)[0]}</strong><br />
                 &amp;nbsp;&amp;nbsp;Reservation Number : <strong>${object.reservation_no}</strong><br />
                 &amp;nbsp;&amp;nbsp;Number Of Persons : <strong>${object.adults}</strong> Adults and <strong>${object.children}</strong> Childrens<br />
                 </p>

--- a/hotel_reservation/report/checkin_report_template.xml
+++ b/hotel_reservation/report/checkin_report_template.xml
@@ -15,9 +15,9 @@
                         <div class="row mt32 mb32">
                             <div class="text-center">
                                 <strong>From:</strong>
-                                <span t-esc="data['date_start']" />
+                                <span t-esc="date_start" />
                                 <strong>To:</strong>
-                                <span t-esc="data['date_end']" />
+                                <span t-esc="date_end" />
                             </div>
                         </div>
                         <table class="table table-condensed">
@@ -40,16 +40,16 @@
                             </tr>
                             <tr t-foreach="get_checkin" t-as="info">
                                 <td>
-                                    <span t-field="info.reservation_no" />
+                                    <span t-esc="info['reservation_no']" />
                                 </td>
                                 <td>
-                                    <span t-field="info.partner_id.name" />
+                                    <span t-esc="info['partner_id'].name" />
                                 </td>
                                 <td>
-                                    <span t-field="info.checkin" />
+                                    <span t-esc="info['checkin']"/>
                                 </td>
                                 <td>
-                                    <table t-foreach="info.reservation_line" t-as="line">
+                                    <table t-foreach="info['reservation_line']" t-as="line">
                                         <tr>
                                             <td>
                                                 <span t-field="line.categ_id.name" />
@@ -58,7 +58,7 @@
                                     </table>
                                 </td>
                                 <td>
-                                    <table t-foreach="info.reservation_line" t-as="line">
+                                    <table t-foreach="info['reservation_line']" t-as="line">
                                         <tr t-foreach="line.reserve" t-as="o">
                                             <td>
                                                 <span t-field="o.name" />

--- a/hotel_reservation/report/checkout_report_template.xml
+++ b/hotel_reservation/report/checkout_report_template.xml
@@ -19,9 +19,9 @@
                         <div class="row mt32 mb32">
                             <div class="text-center">
                                 <strong>From:</strong>
-                                <span t-esc="data['date_start']" />
+                                <span t-esc="date_start" />
                                 <strong>To:</strong>
-                                <span t-esc="data['date_end']" />
+                                <span t-esc="date_end" />
                             </div>
                         </div>
                         <table class="table table-condensed">
@@ -43,17 +43,17 @@
                                 </td>
                             </tr>
                             <tr t-foreach="get_checkout" t-as="info">
-                                <td>
-                                    <span t-field="info.reservation_no" />
+								<td>
+                                    <span t-esc="info['reservation_no']" />
                                 </td>
                                 <td>
-                                    <span t-field="info.partner_id.name" />
+                                    <span t-esc="info['partner_id'].name" />
                                 </td>
                                 <td>
-                                    <span t-field="info.checkin" />
+                                    <span t-esc="info['checkout']"/>
                                 </td>
                                 <td>
-                                    <table t-foreach="info.reservation_line" t-as="line">
+                                    <table t-foreach="info['reservation_line']" t-as="line">
                                         <tr>
                                             <td>
                                                 <span t-field="line.categ_id.name" />
@@ -63,7 +63,7 @@
                                     </table>
                                 </td>
                                 <td>
-                                    <table t-foreach="info.reservation_line" t-as="line">
+                                    <table t-foreach="info['reservation_line']" t-as="line">
                                         <tr t-foreach="line.reserve" t-as="o">
                                             <td>
                                                 <span t-field="o.name" />

--- a/hotel_reservation/report/hotel_reservation_report.py
+++ b/hotel_reservation/report/hotel_reservation_report.py
@@ -1,11 +1,11 @@
 # See LICENSE file for full copyright and licensing details.
 
 import time
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from dateutil.relativedelta import relativedelta
 from odoo import api, fields, models
 from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
-
+import pytz
 
 class ReportTestCheckin(models.AbstractModel):
     _name = "report.hotel_reservation.report_checkin_qweb"
@@ -24,12 +24,32 @@ class ReportTestCheckin(models.AbstractModel):
                                       ('checkout', '<=', date_end)])
         return res
 
-    def get_checkin(self, date_start, date_end):
+    def get_checkin(self, date_start, date_end, user_lang, to_zone):
         reservation_obj = self.env['hotel.reservation']
         res = reservation_obj.search([('checkin', '>=', date_start),
                                       ('checkin', '<=', date_end)])
-        return res
+        new_res = []
+        for reservation in res:
+            new_checkin = self.format_date(reservation.checkin, user_lang, to_zone)
+            new_res.append({'reservation_no': reservation.reservation_no,
+                            'checkin': new_checkin,
+                            'partner_id': reservation.partner_id,
+                            'reservation_line': reservation.reservation_line,
+                            })
+        return new_res
 
+    def format_date(self, date, user_lang, to_zone):
+        if isinstance(date, str):
+            new_date = datetime.strptime(date, '%Y-%m-%d %H:%M:%S')
+        else:
+            new_date = date
+        timezone_conv = pytz.timezone(to_zone)
+        timezone_utc = pytz.timezone('UTC')
+        new_date = timezone_utc.localize(new_date)
+        new_date = new_date.astimezone(timezone_conv)
+        date_converted = new_date.strftime(user_lang.date_format+" "+user_lang.time_format)
+        return date_converted
+    
     @api.model
     def _get_report_values(self, docids, data):
         self.model = self.env.context.get('active_model')
@@ -37,15 +57,25 @@ class ReportTestCheckin(models.AbstractModel):
             data = {}
         if not docids:
             docids = data['form'].get('docids')
+        context = self._context
+        current_uid = context.get('uid')
+        user = self.env['res.users'].browse(current_uid)
+        user_lang = self.env['res.lang'].search([('code', '=', user.lang)])[0]
+        if self._context.get('tz'):
+            to_zone = self._context.get('tz')
+        else:
+            to_zone = 'UTC'
+        rm_act = self.with_context(data['form'].get('used_context', {}))
         folio_profile = self.env['hotel.reservation'].browse(docids)
-        date_start = data.get('date_start', fields.Date.today())
+        date_start = data['form'].get('date_start', str(datetime.now())[:10])
         date_end = data['form'].get('date_end', str(datetime.now() +
                                     relativedelta(months=+1,
                                                   day=1, days=-1))[:10])
-        rm_act = self.with_context(data['form'].get('used_context', {}))
+        date_start_formatted = rm_act.format_date(date_start, user_lang, to_zone)
+        date_end_formatted = rm_act.format_date(date_end, user_lang, to_zone)
         _get_room_type = rm_act._get_room_type(date_start, date_end)
         _get_room_nos = rm_act._get_room_nos(date_start, date_end)
-        get_checkin = rm_act.get_checkin(date_start, date_end)
+        get_checkin = rm_act.get_checkin(date_start, date_end, user_lang, to_zone)
         return {
             'doc_ids': docids,
             'doc_model': self.model,
@@ -55,6 +85,8 @@ class ReportTestCheckin(models.AbstractModel):
             'get_room_type': _get_room_type,
             'get_room_nos': _get_room_nos,
             'get_checkin': get_checkin,
+            'date_start': date_start_formatted,
+            'date_end': date_end_formatted
         }
 
 
@@ -74,11 +106,31 @@ class ReportTestCheckout(models.AbstractModel):
                                       ('checkout', '<=', date_end)])
         return res
 
-    def _get_checkout(self, date_start, date_end):
+    def _get_checkout(self, date_start, date_end, user_lang, to_zone):
         reservation_obj = self.env['hotel.reservation']
         res = reservation_obj.search([('checkout', '>=', date_start),
                                       ('checkout', '<=', date_end)])
-        return res
+        new_res = []
+        for reservation in res:
+            new_checkout = self.format_date(reservation.checkout, user_lang, to_zone)
+            new_res.append({'reservation_no': reservation.reservation_no,
+                            'checkout': new_checkout,
+                            'partner_id': reservation.partner_id,
+                            'reservation_line': reservation.reservation_line,
+                            })
+        return new_res
+
+    def format_date(self, date, user_lang, to_zone):
+        if isinstance(date, str):
+            new_date = datetime.strptime(date, '%Y-%m-%d %H:%M:%S')
+        else:
+            new_date = date
+        timezone_conv = pytz.timezone(to_zone)
+        timezone_utc = pytz.timezone('UTC')
+        new_date = timezone_utc.localize(new_date)
+        new_date = new_date.astimezone(timezone_conv)
+        date_converted = new_date.strftime(user_lang.date_format+" "+user_lang.time_format)
+        return date_converted
 
     @api.model
     def _get_report_values(self, docids, data):
@@ -87,15 +139,25 @@ class ReportTestCheckout(models.AbstractModel):
             data = {}
         if not docids:
             docids = data['form'].get('docids')
+        context = self._context
+        current_uid = context.get('uid')
+        user = self.env['res.users'].browse(current_uid)
+        user_lang = self.env['res.lang'].search([('code', '=', user.lang)])[0]
+        if self._context.get('tz'):
+            to_zone = self._context.get('tz')
+        else:
+            to_zone = 'UTC'
+        rm_act = self.with_context(data['form'].get('used_context', {}))
         folio_profile = self.env['hotel.reservation'].browse(docids)
-        date_start = data.get('date_start', fields.Date.today())
+        date_start = data['form'].get('date_start', str(datetime.now())[:10])
         date_end = data['form'].get('date_end', str(datetime.now() +
                                     relativedelta(months=+1,
                                                   day=1, days=-1))[:10])
-        rm_act = self.with_context(data['form'].get('used_context', {}))
+        date_start_formatted = rm_act.format_date(date_start, user_lang, to_zone)
+        date_end_formatted = rm_act.format_date(date_end, user_lang, to_zone)
         _get_room_type = rm_act._get_room_type(date_start, date_end)
         _get_room_nos = rm_act._get_room_nos(date_start, date_end)
-        _get_checkout = rm_act._get_checkout(date_start, date_end)
+        get_checkout = rm_act._get_checkout(date_start, date_end, user_lang, to_zone)
         return {
             'doc_ids': docids,
             'doc_model': self.model,
@@ -104,7 +166,9 @@ class ReportTestCheckout(models.AbstractModel):
             'time': time,
             'get_room_type': _get_room_type,
             'get_room_nos': _get_room_nos,
-            'get_checkout': _get_checkout,
+            'get_checkout': get_checkout,
+            'date_start': date_start_formatted,
+            'date_end': date_end_formatted
         }
 
 
@@ -154,6 +218,18 @@ class ReportTestMaxroom(models.AbstractModel):
                 room_used_details.append(details)
         return room_used_details
 
+    def format_date(self, date, user_lang, to_zone):
+        if isinstance(date, str):
+            new_date = datetime.strptime(date, '%Y-%m-%d %H:%M:%S')
+        else:
+            new_date = date
+        timezone_conv = pytz.timezone(to_zone)
+        timezone_utc = pytz.timezone('UTC')
+        new_date = timezone_utc.localize(new_date)
+        new_date = new_date.astimezone(timezone_conv)
+        date_converted = new_date.strftime(user_lang.date_format+" "+user_lang.time_format)
+        return date_converted
+
     @api.model
     def _get_report_values(self, docids, data):
         self.model = self.env.context.get('active_model')
@@ -161,12 +237,22 @@ class ReportTestMaxroom(models.AbstractModel):
             data = {}
         if not docids:
             docids = data['form'].get('docids')
+        context = self._context
+        current_uid = context.get('uid')
+        user = self.env['res.users'].browse(current_uid)
+        user_lang = self.env['res.lang'].search([('code', '=', user.lang)])[0]
+        if self._context.get('tz'):
+            to_zone = self._context.get('tz')
+        else:
+            to_zone = 'UTC'
+        rm_act = self.with_context(data['form'].get('used_context', {}))
         folio_profile = self.env['hotel.reservation'].browse(docids)
-        date_start = data['form'].get('date_start', fields.Date.today())
+        date_start = data['form'].get('date_start', str(datetime.now())[:10])
         date_end = data['form'].get('date_end', str(datetime.now() +
                                     relativedelta(months=+1,
                                                   day=1, days=-1))[:10])
-        rm_act = self.with_context(data['form'].get('used_context', {}))
+        date_start_formatted = rm_act.format_date(date_start, user_lang, to_zone)
+        date_end_formatted = rm_act.format_date(date_end, user_lang, to_zone)
         _get_room_type = rm_act._get_room_type(date_start, date_end)
         _get_room_nos = rm_act._get_room_nos(date_start, date_end)
         _get_data = rm_act._get_data(date_start, date_end)
@@ -182,6 +268,8 @@ class ReportTestMaxroom(models.AbstractModel):
             'get_room_nos': _get_room_nos,
             'get_data': _get_data,
             'get_room_used_detail': _get_room_used_detail,
+            'date_start': date_start_formatted,
+            'date_end': date_end_formatted
         }
 
 
@@ -203,11 +291,33 @@ class ReportTestRoomres(models.AbstractModel):
         res = reservation_obj.browse(tids)
         return res
 
-    def _get_data(self, date_start, date_end):
+    def _get_data(self, date_start, date_end, user_lang, to_zone):
         reservation_obj = self.env['hotel.reservation']
         res = reservation_obj.search([('checkin', '>=', date_start),
                                       ('checkout', '<=', date_end)])
-        return res
+        new_res = []
+        for reservation in res:
+            new_checkout = self.format_date(reservation.checkout, user_lang, to_zone)
+            new_checkin = self.format_date(reservation.checkin, user_lang, to_zone)
+            new_res.append({'reservation_no': reservation.reservation_no,
+                            'checkout': new_checkout,
+                            'checkin': new_checkin,
+                            'partner_id': reservation.partner_id,
+                            'reservation_line': reservation.reservation_line,
+                            })
+        return new_res
+
+    def format_date(self, date, user_lang, to_zone):
+        if isinstance(date, str):
+            new_date = datetime.strptime(date, '%Y-%m-%d %H:%M:%S')
+        else:
+            new_date = date
+        timezone_conv = pytz.timezone(to_zone)
+        timezone_utc = pytz.timezone('UTC')
+        new_date = timezone_utc.localize(new_date)
+        new_date = new_date.astimezone(timezone_conv)
+        date_converted = new_date.strftime(user_lang.date_format+" "+user_lang.time_format)
+        return date_converted
 
     @api.model
     def _get_report_values(self, docids, data):
@@ -216,15 +326,25 @@ class ReportTestRoomres(models.AbstractModel):
             data = {}
         if not docids:
             docids = data['form'].get('docids')
+        context = self._context
+        current_uid = context.get('uid')
+        user = self.env['res.users'].browse(current_uid)
+        user_lang = self.env['res.lang'].search([('code', '=', user.lang)])[0]
+        if self._context.get('tz'):
+            to_zone = self._context.get('tz')
+        else:
+            to_zone = 'UTC'
+        rm_act = self.with_context(data['form'].get('used_context', {}))
         folio_profile = self.env['hotel.reservation'].browse(docids)
-        date_start = data.get('date_start', fields.Date.today())
+        date_start = data['form'].get('date_start', str(datetime.now())[:10])
         date_end = data['form'].get('date_end', str(datetime.now() +
                                     relativedelta(months=+1,
                                                   day=1, days=-1))[:10])
-        rm_act = self.with_context(data['form'].get('used_context', {}))
+        date_start_formatted = rm_act.format_date(date_start, user_lang, to_zone)
+        date_end_formatted = rm_act.format_date(date_end, user_lang, to_zone)
         _get_room_type = rm_act._get_room_type(date_start, date_end)
         _get_room_nos = rm_act._get_room_nos(date_start, date_end)
-        _get_data = rm_act._get_data(date_start, date_end)
+        _get_data = rm_act._get_data(date_start, date_end, user_lang, to_zone)
         return {
             'doc_ids': docids,
             'doc_model': self.model,
@@ -234,4 +354,6 @@ class ReportTestRoomres(models.AbstractModel):
             'get_room_type': _get_room_type,
             'get_room_nos': _get_room_nos,
             'get_data': _get_data,
+            'date_start': date_start_formatted,
+            'date_end': date_end_formatted
         }

--- a/hotel_reservation/report/hotel_reservation_report_template.xml
+++ b/hotel_reservation/report/hotel_reservation_report_template.xml
@@ -19,9 +19,9 @@
                         <div class="row mt32 mb32">
                             <div class="text-center">
                                 <strong>From:</strong>
-                                <span t-esc="data['date_start']" />
+                                <span t-esc="date_start" />
                                 <strong>To:</strong>
-                                <span t-esc="data['date_end']" />
+                                <span t-esc="date_end" />
                             </div>
                         </div>
                         <table class="table table-condensed">
@@ -44,19 +44,19 @@
                             </tr>
                             <tr t-foreach="get_data" t-as="info">
                                 <td>
-                                    <span t-field="info.reservation_no" />
+                                    <span t-esc="info['reservation_no']" />
                                 </td>
                                 <td>
-                                    <span t-field="info.partner_id.name" />
+                                    <span t-esc="info['partner_id'].name" />
                                 </td>
                                 <td>
-                                    <span t-field="info.checkin" />
+                                    <span t-esc="info['checkin']" />
                                 </td>
                                 <td>
-                                    <span t-field="info.checkout" />
+                                    <span t-esc="info['checkout']" />
                                 </td>
                                 <td>
-                                    <table t-foreach="info.reservation_line" t-as="line">
+                                    <table t-foreach="info['reservation_line']" t-as="line">
                                         <tr>
                                             <td>
                                                 <span t-field="line.categ_id.name" />

--- a/hotel_reservation/report/room_max_report_template.xml
+++ b/hotel_reservation/report/room_max_report_template.xml
@@ -19,9 +19,9 @@
                         <div class="row mt32 mb32">
                             <div class="text-center">
                                 <strong>From:</strong>
-                                <span t-esc="data['date_start']" />
+                                <span t-esc="date_start" />
                                 <strong>To:</strong>
-                                <span t-esc="data['date_end']" />
+                                <span t-esc="date_end" />
                             </div>
                         </div>
                         <table class="table table-condensed">

--- a/hotel_reservation/static/src/css/room_summary.css
+++ b/hotel_reservation/static/src/css/room_summary.css
@@ -17,7 +17,7 @@
 }
 .table_reserved1
 {
-	background-color: blue;
+	background-color: orange;
 	color: white;
 	text-align: center;
 	min-width:100px;

--- a/hotel_reservation/static/src/js/hotel_room_summary.js
+++ b/hotel_reservation/static/src/js/hotel_room_summary.js
@@ -53,11 +53,34 @@ var MyWidget = FieldText.extend({
          var self = this
          this.$el.find(".table_free").bind("click", function(event){
              self.do_action({
+            	 	 name: 'Reservation',
                      type: 'ir.actions.act_window',
-                     res_model: "quick.room.reservation",
+                     res_model: "hotel.reservation",
                      views: [[false, 'form']],
                      target: 'new',
-                     context: {"room_id": $(this).attr("data"), 'date': $(this).attr("date"), 'default_adults': 1},
+                     context: {"room_id": $(this).attr("data"), 'date': $(this).attr("date")},
+             });
+         });
+         this.$el.find(".table_reserved").bind("click", function(event){
+             self.do_action({
+            	 	 name: 'Reservation',
+                     type: 'ir.actions.act_window',
+                     res_model: "hotel.reservation",
+                     res_id: parseInt($(this).attr("data")),
+                     views: [[false, 'form']],
+                     target: 'new',
+                     context: {},
+             });
+         });
+         this.$el.find(".table_reserved1").bind("click", function(event){
+             self.do_action({
+            	 	 name: 'Reservation',
+                     type: 'ir.actions.act_window',
+                     res_model: "hotel.reservation",
+                     res_id: parseInt($(this).attr("data")),
+                     views: [[false, 'form']],
+                     target: 'new',
+                     context: {},
              });
          });
      },

--- a/hotel_reservation/static/src/xml/hotel_room_summary.xml
+++ b/hotel_reservation/static/src/xml/hotel_room_summary.xml
@@ -21,10 +21,10 @@
                                 <td class="table_free"  t-att-data = "status.room_id" t-att-date = "status.date" style="text-align:center;"><t t-esc="status.state"/></td>
                             </t>
                             <t t-if="status.state != 'Free' and status.is_draft == 'No'">
-                                <td class="table_reserved" t-att-data-model="status.data_model" t-att-data-id="status.data_id" style="text-align:center;" ><t t-esc="status.state"/></td>
+                                <td class="table_reserved" t-att-data = "status.reservation_id" t-att-data-model="status.data_model" t-att-data-id="status.data_id" style="text-align:center;" ><t t-esc="status.state"/></td>
                             </t>
                             <t t-if="status.is_draft == 'Yes'">
-                                <td class="table_reserved1" t-att-data-model="status.data_model" t-att-data-id="status.data_id" style="text-align:center;" ><t t-esc="status.state"/></td>
+                                <td class="table_reserved1" t-att-data = "status.reservation_id" t-att-data-model="status.data_model" t-att-data-id="status.data_id" style="text-align:center;" ><t t-esc="status.state"/></td>
                             </t>
                         </t>
                     </tr>

--- a/hotel_reservation/views/hotel_reservation_view.xml
+++ b/hotel_reservation/views/hotel_reservation_view.xml
@@ -69,7 +69,7 @@
                                         nolabel="1" />
                                 </form>
                                 <tree string="Reservation Line">
-                                    <field name="reserve" string="Rooms" widget="many2many_tags" />
+                                    <field name="reserve" string="Rooms" widget="many2many_tags"/>
                                 </tree>
                             </field>
                         </page>
@@ -78,6 +78,10 @@
                         </page>
                     </notebook>
                 </sheet>
+                <div class="oe_chatter">
+					<field name="message_follower_ids" widget="mail_followers"/>
+					<field name="message_ids" widget="mail_thread"/>
+				</div>
             </form>
         </field>
     </record>
@@ -105,8 +109,9 @@
         <field name="arch" type="xml">
             <search string="Reservation">
                 <filter name='current_reservations' string="Current Reservations"
-                    domain="[('checkout','&gt;=',datetime.datetime.now().replace(hour=0, minute=0, second=0)),('checkin','&lt;=',datetime.datetime.now().replace(hour=23, minute=59, second=59))]"
+                    domain="[('checkin','&gt;=',datetime.datetime.now().replace(hour=0, minute=0, second=0))]"
                     help="Current Reservations" />
+                <field name='reservation_line' string="Room" />
                 <filter name='draft' domain="[('state','=','draft')]" string="Draft" />
                 <filter name='confirm' domain="[('state','=','confirm')]" string="Confirm" />
                 <filter name='cancel' domain="[('state','=','cancel')]" string="Cancel" />
@@ -201,39 +206,6 @@
         </field>
     </record>
 
-    <record id="view_hotel_folio_form_inherited" model="ir.ui.view">
-        <field name="name">hotel.folio.form.inherited</field>
-        <field name="model">hotel.folio</field>
-        <field name="inherit_id" ref="hotel.view_hotel_folio_form" />
-        <field name="arch" type="xml">
-            <field name="name" position='after'>
-                <field name="reservation_id" readonly='1' />
-            </field>
-        </field>
-    </record>
-
-    <record id="view_hotel_folio_tree_inherited" model="ir.ui.view">
-        <field name="name">hotel.folio.tree.inherited</field>
-        <field name="model">hotel.folio</field>
-        <field name="inherit_id" ref="hotel.view_hotel_folio_tree" />
-        <field name="arch" type="xml">
-            <field name="name" position='after'>
-                <field name="reservation_id" />
-            </field>
-        </field>
-    </record>
-
-    <record id="view_hotel_folio1_search_inherited" model="ir.ui.view">
-        <field name="name">hotel.folio.search.inherited</field>
-        <field name="model">hotel.folio</field>
-        <field name="inherit_id" ref="hotel.view_hotel_folio_search" />
-        <field name="arch" type="xml">
-            <field name="name" position='after'>
-                <field name="reservation_id" />
-            </field>
-        </field>
-    </record>
-
     <!-- Form view of room reservation summary -->
     <record id="room_reservation_summary_form_view" model="ir.ui.view">
         <field name="name">room.reservation.summary.form</field>
@@ -260,40 +232,6 @@
                         </page>
                     </notebook>
                 </sheet>
-            </form>
-        </field>
-    </record>
-
-    <!-- Form view of quick room reservation -->
-    <record id="quick_room_reservation_form_view" model="ir.ui.view">
-        <field name="name">quick.room.reservation.form</field>
-        <field name="model">quick.room.reservation</field>
-        <field name="arch" type="xml">
-            <form string="Quick Reservation">
-                <header>
-                    <separator string="Quick Reservation" colspan="4" />
-                </header>
-                <sheet>
-                    <group colspan="4" col="4">
-                        <field name="partner_id" />
-                        <field name="room_id" readonly="1" />
-                        <field name="check_in" />
-                        <field name="check_out" />
-                        <field name="warehouse_id" />
-                        <field name="pricelist_id" />
-                        <field name="partner_invoice_id" />
-                        <field name="partner_order_id" />
-                        <field name="partner_shipping_id" />
-                        <field name="adults" />
-                    </group>
-                </sheet>
-                <footer>
-                    <group colspan="2" col="2">
-                        <button string="Save" name="room_reserve" type="object"
-                            class="btn-primary" />
-                        <button string="Cancel" special="cancel" class="btn-primary" />
-                    </group>
-                </footer>
             </form>
         </field>
     </record>

--- a/hotel_reservation/wizards/hotel_reservation_wizard.py
+++ b/hotel_reservation/wizards/hotel_reservation_wizard.py
@@ -1,14 +1,92 @@
 # See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models
+import time
+from datetime import datetime, timedelta
+from odoo import api, fields, models, _
+from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
 
+from odoo.exceptions import ValidationError
+
+def _offset_format_timestamp1(src_tstamp_str, src_format, dst_format,
+                              ignore_unparsable_time=True, context=None):
+    """
+    Convert a source timeStamp string into a destination timeStamp string,
+    attempting to apply the correct offset if both the server and local
+    timeZone are recognized,or no offset at all if they aren't or if
+    tz_offset is false (i.e. assuming they are both in the same TZ).
+
+    @param src_tstamp_str: the STR value containing the timeStamp.
+    @param src_format: the format to use when parsing the local timeStamp.
+    @param dst_format: the format to use when formatting the resulting
+     timeStamp.
+    @param server_to_client: specify timeZone offset direction (server=src
+                             and client=dest if True, or client=src and
+                             server=dest if False)
+    @param ignore_unparsable_time: if True, return False if src_tstamp_str
+                                   cannot be parsed using src_format or
+                                   formatted using dst_format.
+    @return: destination formatted timestamp, expressed in the destination
+             timezone if possible and if tz_offset is true, or src_tstamp_str
+             if timezone offset could not be determined.
+    """
+    if not src_tstamp_str:
+        return False
+    res = src_tstamp_str
+    if src_format and dst_format:
+        try:
+            # dt_value needs to be a datetime object\
+            # (so notime.struct_time or mx.DateTime.DateTime here!)
+            dt_value = datetime.strptime(src_tstamp_str, src_format)
+            if context.get('tz', False):
+                try:
+                    import pytz
+                    src_tz = pytz.timezone(context['tz'])
+                    dst_tz = pytz.timezone('UTC')
+                    src_dt = src_tz.localize(dt_value, is_dst=True)
+                    dt_value = src_dt.astimezone(dst_tz)
+                except Exception:
+                    pass
+            res = dt_value.strftime(dst_format)
+        except Exception:
+            # Normal ways to end up here are if strptime or strftime failed
+            if not ignore_unparsable_time:
+                return False
+            pass
+    return res
+
+def _get_checkin_date(self):
+    if self._context.get('tz'):
+        to_zone = self._context.get('tz')
+    else:
+        to_zone = 'UTC'
+    return datetime.strptime(_offset_format_timestamp1
+                             (time.strftime("%Y-%m-%d 15:00:00"),
+                              DEFAULT_SERVER_DATETIME_FORMAT,
+                              '%m/%d/%Y %H:%M:%S',
+                              ignore_unparsable_time=True,
+                              context={'tz': to_zone}),
+                             '%m/%d/%Y %H:%M:%S')
+
+def _get_checkout_date(self):
+    if self._context.get('tz'):
+        to_zone = self._context.get('tz')
+    else:
+        to_zone = 'UTC'
+    tm_delta = timedelta(days=1)
+    return datetime.strptime(_offset_format_timestamp1
+                             (time.strftime("%Y-%m-%d 11:00:00"),
+                              DEFAULT_SERVER_DATETIME_FORMAT,
+                              '%m/%d/%Y %H:%M:%S',
+                              ignore_unparsable_time=True,
+                              context={'tz': to_zone}),
+                             '%m/%d/%Y %H:%M:%S') + tm_delta
 
 class HotelReservationWizard(models.TransientModel):
     _name = 'hotel.reservation.wizard'
     _description = 'Allow to generate a reservation'
 
-    date_start = fields.Datetime('Start Date', required=True)
-    date_end = fields.Datetime('End Date', required=True)
+    date_start = fields.Datetime('Start Date', required=True, default=_get_checkin_date)
+    date_end = fields.Datetime('End Date', required=True, default=_get_checkout_date)
 
     @api.multi
     def report_reservation_detail(self):
@@ -58,18 +136,81 @@ class MakeFolioWizard(models.TransientModel):
     grouped = fields.Boolean('Group the Folios')
 
     @api.multi
-    def makeFolios(self):
-        order_obj = self.env['hotel.reservation']
-        newinv = []
-        for order in order_obj.browse(self.env.context.get('active_ids', [])):
-            for folio in order.folio_id:
-                newinv.append(folio.id)
-        return {
-            'domain': "[('id','in', [" + ','.join(map(str, newinv)) + "])]",
-            'name': 'Folios',
-            'view_type': 'form',
-            'view_mode': 'tree,form',
-            'res_model': 'hotel.folio',
-            'view_id': False,
-            'type': 'ir.actions.act_window'
-        }
+    def create_folio(self):
+        """
+        This method is for create new hotel folio.
+        -----------------------------------------
+        @param self: The object pointer
+        @return: new record set for hotel folio.
+        """
+        hotel_folio_obj = self.env['hotel.folio']
+        room_obj = self.env['hotel.room']
+        reservation_ids = self.env['hotel.reservation'].browse(self._context.get('active_ids'))
+        if len(reservation_ids) >= 1:
+            reservation = reservation_ids[0]
+            folio_lines = []
+            checkin_date = reservation['checkin']
+            checkout_date = reservation['checkout']
+            for res in reservation_ids:
+                if res.state != 'confirm':
+                    raise ValidationError(_('Reservations must be in "Confirm" state to be added to a folio.'))
+                if not res.checkin < res.checkout:
+                    raise ValidationError(_('Checkout date should be greater \
+                                         than the Check-in date.'))
+            duration_vals = (reservation.onchange_check_dates
+                             (checkin_date=checkin_date,
+                              checkout_date=checkout_date, duration=False))
+            duration = duration_vals.get('duration') or 0.0
+            folio_vals = {
+                'date_order': reservation.date_order,
+                'warehouse_id': reservation.warehouse_id.id,
+                'partner_id': reservation.partner_id.id,
+                'pricelist_id': reservation.pricelist_id.id,
+                'partner_invoice_id': reservation.partner_invoice_id.id,
+                'partner_shipping_id': reservation.partner_shipping_id.id,
+                'duration': duration,
+                'reservation_id': reservation.id,
+                'service_lines': reservation['folio_id']
+            }
+            final_checkin = None
+            final_checkout = None
+            for res in reservation_ids:
+                if (final_checkin is None) or (res.checkin < final_checkin):
+                    final_checkin = res.checkin
+                if (final_checkout is None) or (res.checkout > final_checkout):
+                    final_checkout = res.checkout
+                for line in res.reservation_line:
+                    for r in line.reserve:
+                        duration_vals = (res.onchange_check_dates
+                        (checkin_date=checkin_date,
+                         checkout_date=checkout_date, duration=False))
+                        duration = duration_vals.get('duration') or 0.0
+                        checkin_date = res['checkin']
+                        checkout_date = res['checkout']
+                        folio_lines.append((0, 0, {
+                            'checkin_date': checkin_date,
+                            'checkout_date': checkout_date,
+                            'product_id': r.product_id and r.product_id.id,
+                            'name': res['reservation_no'],
+                            'price_unit': r.list_price,
+                            'product_uom_qty': duration,
+                            'is_reserved': True,
+                            'reservation' : res.id}))
+                        res_obj = room_obj.browse([r.id])
+                        res_obj.write({'status': 'occupied', 'isroom': False})
+                res.state = 'done'
+            folio_vals.update({'room_lines': folio_lines, 'checkin_date': final_checkin, 'checkout_date': final_checkout})
+            folio = hotel_folio_obj.create(folio_vals)
+            if folio:
+                for rm_line in folio.room_lines:
+                    rm_line.product_id_change()
+            self._cr.execute('insert into hotel_folio_reservation_rel'
+                             '(order_id, invoice_id) values (%s,%s)',
+                             (reservation.id, folio.id))
+            return {
+                'view_type': 'form',
+                'view_mode': 'form',
+                'res_model': 'hotel.folio',
+                'res_id': folio.id,
+                'type': 'ir.actions.act_window'
+            }

--- a/hotel_reservation/wizards/hotel_reservation_wizard.xml
+++ b/hotel_reservation/wizards/hotel_reservation_wizard.xml
@@ -39,15 +39,14 @@
     <!--Form view for wizard make folio -->
     <record id="make_folio_wizard_form_view" model="ir.ui.view">
         <field name="name">make.folio.wizard.form</field>
-        <field name="model">wizard.make.folio</field>
+        <field name="res_model">wizard.make.folio</field>
         <field name="arch" type="xml">
             <form string="Create Folio" version='8.0'>
                 <separator colspan="4"
                     string="Do you really want to create the Folio ?" />
-                <!-- <field name="grouped" /> -->
                 <newline />
                 <footer>
-                    <button name="makeFolios" string="Create Folio" type="object"
+                    <button name="create_folio" string="Create Folio" type="object"
                         icon="fa-files-o" class="oe_highlight" />
                     <button string="Cancel" icon="fa-close" class="btn btn-primary" special="cancel" />
                 </footer>
@@ -56,7 +55,7 @@
     </record>
 
     <act_window id="act_make_folio"
-                name="Make Folios"
+                name="Create Folio"
                 key2="client_action_multi"
                 res_model="wizard.make.folio"
                 src_model="hotel.reservation"


### PR DESCRIPTION
- Add OpenChatter to Reservations and Folios
- Fix date format in reports to display according to user locale
- Set default check-in time to 15:00 and default check-out time to 11:00
- Open a new standard reservation form if a free cell is clicked in
reservation summary, not a quick reservation form
- Display draft reservation in orange in the reservation summary
- Also if multiple draft reservations are set on the same day, a warning
character is displayed in the reservation summary
- A click on a draft or validated reservation in the reservation summary
opens the reservation
- The current reservation start date filter checks only if the
reservation check-in is later than the current date
- It is possible to create a folio containing multiple reservations by
selecting the reservations and then clicking on "Create Folio"
- If a folio is deleted, the reservations are put back to draft status