### PR TITLE
[11.0][ADD] pricelist support for rooms

### DIFF
--- a/hotel/models/hotel_folio_line.py
+++ b/hotel/models/hotel_folio_line.py
@@ -151,7 +151,8 @@ class HotelFolioLine(models.Model):
                         price,
                         rule_id,
                     ) = pricelist_item.base_pricelist_id.with_context(
-                        uom=uom.id
+                        uom=uom.id,
+                        date=fields.Date.from_string(self.checkin_date),
                     ).get_product_price_rule(
                         product, qty, self.folio_id.partner_id
                     )
@@ -199,12 +200,13 @@ class HotelFolioLine(models.Model):
         # TO DO: move me in master/saas-16 on sale.order
         if self.folio_id.pricelist_id.discount_policy == "with_discount":
             return product.with_context(
-                pricelist=self.folio_id.pricelist_id.id
+                pricelist=self.folio_id.pricelist_id.id,
+                date=fields.Date.from_string(self.checkin_date),
             ).price
         product_context = dict(
             self.env.context,
             partner_id=self.folio_id.partner_id.id,
-            date=self.folio_id.date_order,
+            date=fields.Date.from_string(self.checkin_date),
             uom=self.product_uom.id,
         )
         final_price, rule_id = self.folio_id.pricelist_id.with_context(
@@ -254,7 +256,7 @@ class HotelFolioLine(models.Model):
             )
 
     @api.multi
-    @api.onchange("product_id")
+    @api.onchange("product_id", "checkin_date", "checkout_date")
     def product_id_change(self):
 
         if not self.product_id:
@@ -273,7 +275,7 @@ class HotelFolioLine(models.Model):
             lang=self.folio_id.partner_id.lang,
             partner=self.folio_id.partner_id.id,
             quantity=vals.get("product_uom_qty") or self.product_uom_qty,
-            date=self.folio_id.date_order,
+            date=fields.Date.from_string(self.checkin_date),
             pricelist=self.folio_id.pricelist_id.id,
             uom=self.product_uom.id,
         )

--- a/hotel/views/hotel_room.xml
+++ b/hotel/views/hotel_room.xml
@@ -62,6 +62,24 @@
                                 <field name="capacity"/>
                                 <field name="uom_id" invisible="1"/>
                             </group>
+                            <div name="pricelist_item" groups="product.group_product_pricelist">
+                                <newline/>
+                                <separator colspan='4' string="Pricing"/>
+                                <group>
+                                    <group>
+                                        <field name="list_price"/>
+                                    </group>
+                                </group>
+                                <field name="item_ids" nolabel="1" context="{'default_base':'list_price', 'default_applied_on' :'1_product'}">
+                                    <tree string="Pricelist Items" editable="bottom">
+                                        <field name="pricelist_id" string="Pricelist" required='1'/>
+                                        <field name="fixed_price" string="Price" required='1'/>
+                                        <field name="date_start"/>
+                                        <field name="date_end"/>
+                                        <field name="applied_on" invisible="1"/>
+                                    </tree>
+                                </field>
+                            </div>
                             <newline/>
                             <separator colspan='4' string="Supplier Taxes"/>
                             <field name="supplier_taxes_id" colspan="4"


### PR DESCRIPTION
This PR adds pricelist support for rooms, so as to enable seasonal room pricing.

When the "Multiple Sales Prices per Product" option is checked in Configuration > General Configuration > Sales, the pricelist view becomes visible on the room form views (as it does on products in standard Odoo). Pricelist rule lines can then be added for a product, and are taken into account when a folio line is created (either directly or coming from a reservation), using the checkin day.

Note that when multiple price list rule lines are valid between the folio checkin date and checkout date, currently the rule line valid during the checkin date is used for the entire folio line.
Hence, an improvement of the current state would be to split the folio lines from one line per room to one line room and price when a reservation is confirmed and it's folio is created.

**Please do not merge before confirmation**
