### PR TITLE
[11.0][ADD] multi folio confirm invoice

### DIFF
--- a/hotel/models/hotel_folio.py
+++ b/hotel/models/hotel_folio.py
@@ -409,20 +409,20 @@ class HotelFolio(models.Model):
         """
         # fixme does not seem to go through here
         room_lst = []
-        invoice_id = self.mapped("order_id").action_invoice_create(
+        invoice_list = self.mapped("order_id").action_invoice_create(
             grouped=False, final=False
         )
-        for line in self:
-            values = {"invoiced": True, "hotel_invoice_id": invoice_id[0]}
-            line.write(values)
-            for rec in line.room_lines:
+        for folio in self:
+            values = {"invoiced": True, "hotel_invoice_id": invoice_list[0]}
+            folio.write(values)
+            for rec in folio.room_lines:
                 room_lst.append(rec.product_id)
             for room in room_lst:
                 room_rec = self.env["hotel.room"].search(
                     [("name", "=", room.name)]
                 )
                 room_rec.write({"isroom": True})
-        return invoice_id
+        return invoice_list
 
     @api.multi
     def action_invoice_cancel(self):

--- a/hotel/models/hotel_folio.py
+++ b/hotel/models/hotel_folio.py
@@ -409,11 +409,11 @@ class HotelFolio(models.Model):
         """
         # fixme does not seem to go through here
         room_lst = []
-        invoice_id = self.order_id.action_invoice_create(
+        invoice_id = self.mapped("order_id").action_invoice_create(
             grouped=False, final=False
         )
         for line in self:
-            values = {"invoiced": True, "hotel_invoice_id": invoice_id}
+            values = {"invoiced": True, "hotel_invoice_id": invoice_id[0]}
             line.write(values)
             for rec in line.room_lines:
                 room_lst.append(rec.product_id)
@@ -451,7 +451,7 @@ class HotelFolio(models.Model):
 
     @api.multi
     def action_confirm(self):
-        for order in self.order_id:
+        for order in self.mapped("order_id"):
             order.state = "sale"
             if not order.analytic_account_id:
                 for line in order.order_line:
@@ -460,7 +460,7 @@ class HotelFolio(models.Model):
                         break
         config_parameter_obj = self.env["ir.config_parameter"]
         if config_parameter_obj.sudo().get_param("sale.auto_done_setting"):
-            self.order_id.action_done()
+            self.mapped("order_id").action_done()
 
     @api.multi
     def test_state(self, mode):

--- a/hotel/views/actions.xml
+++ b/hotel/views/actions.xml
@@ -87,7 +87,6 @@
         <field name="model_id" ref="model_hotel_folio"/>
         <field name="binding_model_id" ref="model_hotel_folio"/>
         <field name="state">code</field>
-        <field name="multi" eval="True"/>
         <field name="code">
             records.action_confirm()
         </field>
@@ -99,7 +98,6 @@
         <field name="model_id" ref="model_hotel_folio"/>
         <field name="binding_model_id" ref="model_hotel_folio"/>
         <field name="state">code</field>
-        <field name="multi" eval="True"/>
         <field name="code">
             records.action_invoice_create()
         </field>

--- a/hotel/views/actions.xml
+++ b/hotel/views/actions.xml
@@ -81,4 +81,28 @@
         <field name="view_mode">tree,form</field>
     </record>
 
+    <record id="ir_actions_server_confirm" model="ir.actions.server">
+        <field name="name">Confirm Sale</field>
+        <field name="type">ir.actions.server</field>
+        <field name="model_id" ref="model_hotel_folio"/>
+        <field name="binding_model_id" ref="model_hotel_folio"/>
+        <field name="state">code</field>
+        <field name="multi" eval="True"/>
+        <field name="code">
+            records.action_confirm()
+        </field>
+    </record>
+
+    <record id="ir_actions_server_create_invoice" model="ir.actions.server">
+        <field name="name">Create Invoice</field>
+        <field name="type">ir.actions.server</field>
+        <field name="model_id" ref="model_hotel_folio"/>
+        <field name="binding_model_id" ref="model_hotel_folio"/>
+        <field name="state">code</field>
+        <field name="multi" eval="True"/>
+        <field name="code">
+            records.action_invoice_create()
+        </field>
+    </record>
+
 </odoo>

--- a/hotel/views/hotel_folio.xml
+++ b/hotel/views/hotel_folio.xml
@@ -239,6 +239,7 @@
                 <field name="partner_id"/>
                 <field name="date_order"/>
                 <field name="state"/>
+                <field name="invoice_status"/>
                 <field name="amount_total" sum="Total amount"/>
             </tree>
         </field>


### PR DESCRIPTION
This PR adds a multi-selection action in the folio tree view to `Confirm` and `Invoice` multiple folio's. Invoicing multiple folio's leads to one joint invoice, using Odoo's standard invoice merging behaviour.

For the 'invoice' action, I used the `action_invoice_create()` function, which in not used by the `Create Invoice` button (it seems to use the `sale.action_view_sale_advance_payment_inv` action - see the `# fixme does not seem to go through here` mention in `action_invoice_create()`). I don't know why this action isn't used (everything seems to be working fine this way) > would be happy if some could explain this!

For this work I needed to make the actions `action_invoice_create()` and `action_confirm()` work with multiple input. Although they use the `@api.multi` decorator and no mention of `self.ensure_one()`, they weren't working with multiple inputs. It could be a good idea to check the other actions as well!

I couldn't run the tests since they were broken before starting. Will need to take a look at them before merging.

**Don't merge before confirmation**