### PR TITLE
[15.0][IMP] hotel: add web_icon to the Hotel Management menu

### DIFF
--- a/hotel/views/menus.xml
+++ b/hotel/views/menus.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-    <menuitem id="hotel_management_menu" name="Hotel Management" />
+    <menuitem
+        id="hotel_management_menu"
+        name="Hotel Management"
+        web_icon="hotel,static/description/hotel2.png"
+    />
     <menuitem
         id="hotel_configuration_menu"
         name="Configuration"


### PR DESCRIPTION
Added a top-level icon for the hotel module, which is suitable for Odoo Enterprise or for those using [web_responsive ](https://github.com/OCA/web/tree/15.0/web_responsive)in the Community Edition.

Before this PR
---
![image](https://github.com/user-attachments/assets/1a521cea-c8ff-4cd8-b3e3-e7487b7bc082)

After this PR
---
![image](https://github.com/user-attachments/assets/7a5832e9-860a-455c-8a4e-fdb7bfa9016e)

